### PR TITLE
Fix issue with STRING subtypes.

### DIFF
--- a/src/local-time.lisp
+++ b/src/local-time.lisp
@@ -1374,13 +1374,11 @@ elements."
                                   (end (cdr (second parts))))
                              (declare (type (integer 0 #.array-dimension-limit) start end))
                              (passert (<= (- end start) 9))
-                             (let ((new-end (position-if (lambda (el)
-                                                           (declare (type character el))
-                                                           (not (char= #\0 el)))
-                                                         (the (simple-array character (*)) time-string)
-                                                         :start start
-                                                         :end end
-                                                         :from-end t)))
+                             (let ((new-end (position #\0 time-string
+                                                      :test-not #'eql
+                                                      :start start
+                                                      :end end
+                                                      :from-end t)))
                                (when new-end
                                  (setf end (min (1+ new-end)))))
                              (setf nsec (* (the (integer 0 999999999) (parse-integer time-string :start start :end end))


### PR DESCRIPTION
Which allows `(parse-timestring (format-timestring nil (now)))` to work again (tested on SBCL 1.1.6.12, CLISP 2.48) where it previously raised an error on SBCL because `FORMAT-TIMESTRING` returns a `SIMPLE-BASE-STRING`:

```
debugger invoked on a TYPE-ERROR in thread
  The value "2013-04-16T23:44:28.910375+02:00"
  is not of type
    (SIMPLE-ARRAY CHARACTER (*)).
```

Since the `UPGRADED-ARRAY-ELEMENT-TYPE` for `BASE-CHAR` and `CHARACTER` may differ, `(SUBTYPEP 'SIMPLE-STRING '(SIMPLE-ARRAY CHARACTER (*)))` can be true or false between implementations, so `%SPLIT-TIMESTRING` has to use `SIMPLE-STRING` (and `CHARACTER`).

I hope my understanding of this is right and this is the right fix, i.e. just relying on SIMPLE-STRING instead of insisting on a particular array type.

(Actually I'd also wanted to loosen the `SIMPLE-BASE-STRING` restriction on `FORMAT-TIMESTRING`, but I can see why that isn't desirable performance-wise and so won't bother with it.)
