### PR TITLE
Refactor TRANSITION-POSITION to use iteration

### DIFF
--- a/src/local-time.lisp
+++ b/src/local-time.lisp
@@ -429,19 +429,30 @@ In other words:
                  :sec (sec-of timestamp)
                  :day (day-of timestamp)))
 
-(defun transition-position (needle haystack &optional (start 0) (end (1- (length haystack))))
-  (let ((middle (floor (+ end start) 2)))
-    (cond
-      ((>= start end)
-       (if (minusp end)
-           0
-           (max 0 (if (>= needle (elt haystack end)) end (1- end)))))
-      ((= needle (elt haystack middle))
-       middle)
-      ((> needle (elt haystack middle))
-       (transition-position needle haystack (1+ middle) end))
-      (t
-       (transition-position needle haystack start (1- middle))))))
+(defun transition-position (needle haystack)
+  (declare (type integer needle)
+           (type (simple-array integer (*)) haystack))
+  (loop
+     with start = 0
+     with end = (1- (length haystack))
+     for middle = (floor (+ end start) 2)
+     while (and (< start end)
+                (/= needle (elt haystack middle)))
+     do (cond
+          ((> needle (elt haystack middle))
+           (setf start (1+ middle)))
+          (t
+           (setf end (1- middle))))
+     finally
+       (return (max 0 (cond
+                        ((minusp end)
+                         0)
+                        ((= needle (elt haystack middle))
+                         middle)
+                        ((>= needle (elt haystack end))
+                         end)
+                        (t
+                         (1- end)))))))
 
 (defun timestamp-subtimezone (timestamp timezone)
   "Return as multiple values the time zone as the number of seconds east of UTC, a boolean daylight-saving-p, and the customary abbreviation of the timezone."

--- a/test/timezone.lisp
+++ b/test/timezone.lisp
@@ -5,8 +5,37 @@
   (local-time::define-timezone eastern-tz
       (merge-pathnames #p"EST5EDT" local-time::*default-timezone-repository-path*)))
 
+
+
 (deftest transition-position/correct-position ()
-  (is (= 5 (local-time::transition-position 13 #(-15 -10 -5 0 5 10 15 20 25 30 35 40 45 50 55 60)))))
+  (let ((cases '((0 #(1 2 3 4 5) 0)
+                 (1 #(1 2 3 4 5) 0)
+                 (2 #(1 2 3 4 5) 1)
+                 (3 #(1 2 3 4 5) 2)
+                 (4 #(1 2 3 4 5) 3)
+                 (5 #(1 2 3 4 5) 4)
+                 (1 #(1 3 5) 0)
+                 (2 #(1 3 5) 0)
+                 (3 #(1 3 5) 1)
+                 (4 #(1 3 5) 1)
+                 (5 #(1 3 5) 2)
+                 (6 #(1 3 5) 2)
+                 (1 #(1 3 5 7) 0)
+                 (2 #(1 3 5 7) 0)
+                 (3 #(1 3 5 7) 1)
+                 (4 #(1 3 5 7) 1)
+                 (5 #(1 3 5 7) 2)
+                 (6 #(1 3 5 7) 2)
+                 (7 #(1 3 5 7) 3)
+                 (8 #(1 3 5 7) 3)
+                 )))
+    (dolist (case cases)
+      (destructuring-bind (needle haystack want)
+          case
+        (let ((got (local-time::transition-position needle haystack)))
+          (is (= got want)
+              "(transition-position ~a ~a) got ~a, want ~a"
+              needle haystack got want))))))
 
 (deftest test/timezone/decode-timestamp-dst ()
   ;; Testing DST calculation with a known timezone


### PR DESCRIPTION
Using iterative function makes the tests run in 83% of the time of the
old recursive function.
