### PR TITLE
Fix a compilation warning on LispWorks

### DIFF
--- a/src/local-time.lisp
+++ b/src/local-time.lisp
@@ -989,19 +989,6 @@ elements."
              #.(encode-universal-time 0 0 0 1 1 1970 0))
           0))
 
-(defmethod clock-now (clock)
-  (declare (ignore clock))
-  (multiple-value-bind (sec nsec) (%get-current-time)
-    (unix-to-timestamp sec :nsec nsec)))
-
-(defmethod clock-today (clock)
-  (declare (ignore clock))
-  ;; TODO should return a date value, anyhow we will decide to represent it eventually
-  (let ((result (now)))
-    (setf (sec-of result) 0)
-    (setf (nsec-of result) 0)
-    result))
-
 (defvar *clock* t
   "Use the `*clock*' special variable if you need to define your own idea of the current time
 
@@ -1014,6 +1001,19 @@ It should be an instance of a class that responds to one or more of the methods 
 (defun today ()
   "Returns a timestamp representing the present day."
   (clock-today *clock*))
+
+(defmethod clock-now (clock)
+  (declare (ignore clock))
+  (multiple-value-bind (sec nsec) (%get-current-time)
+    (unix-to-timestamp sec :nsec nsec)))
+
+(defmethod clock-today (clock)
+  (declare (ignore clock))
+  ;; TODO should return a date value, anyhow we will decide to represent it eventually
+  (let ((result (now)))
+    (setf (sec-of result) 0)
+    (setf (nsec-of result) 0)
+    result))
 
 (defmacro %defcomparator (name &body body)
   (let ((pair-comparator-name (intern (concatenate 'string "%" (string name)))))


### PR DESCRIPTION
When a function is declared as `inline` on LispWorks, the definition must appear before it is used otherwise a warning is issued ("Warning: Inline declaration for ... not found").
