### PR TITLE
Max min bugfix

### DIFF
--- a/src/local-time.lisp
+++ b/src/local-time.lisp
@@ -509,7 +509,7 @@ In other words:
             timestamp-parts)
     (multiple-value-bind (nsec sec min hour day month year day-of-week daylight-saving-time-p offset)
         (decode-timestamp timestamp :timezone timezone)
-      (declare (ignore nsec day-of-week daylight-saving-time-p))
+      (declare (ignore nsec day-of-week daylight-saving-time-p offset))
       (encode-timestamp 0
                         (if (> part-count 0) 0 sec)
                         (if (> part-count 1) 0 min)
@@ -517,7 +517,6 @@ In other words:
                         (if (> part-count 3) 1 day)
                         (if (> part-count 4) 1 month)
                         year
-                        :offset offset
                         :timezone timezone
                         :into into))))
 
@@ -532,7 +531,7 @@ In other words:
             timestamp-parts)
     (multiple-value-bind (nsec sec min hour day month year day-of-week daylight-saving-time-p offset)
         (decode-timestamp timestamp :timezone timezone)
-      (declare (ignore nsec day-of-week daylight-saving-time-p))
+      (declare (ignore nsec day-of-week daylight-saving-time-p offset))
       (let ((month (if (> part-count 4) 12 month)))
         (encode-timestamp 999999999
                           (if (> part-count 0) 59 sec)
@@ -541,7 +540,6 @@ In other words:
                           (if (> part-count 3) (days-in-month month year) day)
                           month
                           year
-                          :offset offset
                           :timezone timezone
                           :into into)))))
 


### PR DESCRIPTION
I found the following behavior when calling timestamp-minimize-part and timestamp-maximize-part 

LT> (timestamp-minimize-part @2014-11-02T16:20:44.112318-06:00 :hour)
@2014-11-02T01:00:00.000000-05:00
LT> (timestamp-maximize-part @2014-11-02T01:20:44.112318-05:00 :hour)
@2014-11-02T22:59:59.999999-06:00
LT> (timestamp-maximize-part @2015-03-08T01:20:44.112318-06:00 :hour)
@2015-03-09T00:59:59.999999-05:00
LT> (timestamp-minimize-part @2015-03-08T16:20:44.112318-06:00 :hour)
@2015-03-07T23:00:00.000000-06:00

I believe this is unexpected behavior.  This change results in the following:

LT> (timestamp-minimize-part @2014-11-02T16:20:44.112318-06:00 :hour)
@2014-11-02T00:00:00.000000-05:00
LT> (timestamp-maximize-part @2014-11-02T01:20:44.112318-05:00 :hour)
@2014-11-02T23:59:59.999999-06:00
LT> (timestamp-maximize-part @2015-03-08T01:20:44.112318-06:00 :hour)
@2015-03-08T23:59:59.999999-05:00
LT> (timestamp-minimize-part @2015-03-08T16:20:44.112318-06:00 :hour)
@2015-03-08T00:00:00.000000-06:00
