### PR TITLE
fix reread-timezone-repository

### DIFF
--- a/src/local-time.lisp
+++ b/src/local-time.lisp
@@ -426,7 +426,8 @@ In other words:
       (setf *abbreviated-subzone-name->timezone-list* (make-hash-table :test 'equal))
       (cl-fad:walk-directory root-directory #'visitor :directories nil
                              :test (lambda (file)
-                                     (not (find "Etc" (pathname-directory file) :test #'string=))))
+                                     (not (find "Etc" (pathname-directory file) :test #'string=)))
+                             :follow-symlinks nil)
       (cl-fad:walk-directory (merge-pathnames "Etc/" root-directory) #'visitor :directories nil))))
 
 (defmacro make-timestamp (&rest args)


### PR DESCRIPTION
use :follow-symlinks nil while walking the directory to get
the intended names of the zonez. later on in %realize-timezone
the symlinks are resolved to get to the proper file contents.