### PR TITLE
Create a new clock which adjusts for leap seconds.

### DIFF
--- a/doc/local-time.texinfo
+++ b/doc/local-time.texinfo
@@ -601,7 +601,7 @@ If there is no timezone specified in @code{timestring} then
 @itindex format-timestring
 @defun format-timestring (destination timestamp &key (format +iso-8601-format+) (timezone *default-timezone*))
 
-Constructs a string representation of TIMESTAMP according to FORMAT and returns it.  If destination is T, the string is written to *standard-output*.  If destination is a stream, the string is written to the stream.
+Constructs a string representation of TIMESTAMP according to FORMAT and returns it.  If destination is @code{T}, the string is written to @code{*standard-output*}.  If destination is a stream, the string is written to the stream.
 
 FORMAT is a list containing one or more of strings, characters, and keywords.  Strings and characters are output literally, while keywords are replaced by the values here:
 
@@ -691,9 +691,17 @@ Formats the time like format-timestring, but in RFC 3339 format. The options con
 
 @defvr Default *clock*
 
-We expose the *clock* special variable and the following generic
-functions so that applications may re-define the current time or
-date as required.
+The *clock* special variable and the following generic functions are
+exposed so that applications may re-define the current time or date as
+required.  This can be used for testing or to support alternate clocks.
+
+The currently supported values are:
+
+@itemize
+@item @code{t} - Use the standard system clock with no adjustments
+@item @code{leap-second-adjusted} - The system clock, adjusted for leap seconds using the information in *default-timezone*.
+@end itemize
+
 @end defvr
 
 @defun clock-now (clock)

--- a/src/local-time.lisp
+++ b/src/local-time.lisp
@@ -1030,9 +1030,12 @@ elements."
           0))
 
 (defvar *clock* t
-  "Use the `*clock*' special variable if you need to define your own idea of the current time
+  "Use the `*clock*' special variable if you need to define your own idea of the current time.
 
-It should be an instance of a class that responds to one or more of the methods `clock-now', and `clock-today'")
+The value of this variable should have the methods `local-time::clock-now', and
+`local-time::clock-today'. The currently supported values in local-time are:
+  t - use the standard clock
+  local-time:leap-second-adjusted - use a clock which adjusts for leap seconds using the information in *default-timezone*.")
 
 (defun now ()
   "Returns a timestamp representing the present moment."
@@ -1062,11 +1065,15 @@ It should be an instance of a class that responds to one or more of the methods 
       (decf sec (%leap-seconds-offset leap-seconds sec))))
   sec)
 
+(defmethod clock-now ((clock (eql 'leap-second-adjusted)))
+  (multiple-value-bind (sec nsec) (%get-current-time)
+    (unix-to-timestamp (%adjust-sec-for-leap-seconds sec)
+                       :nsec nsec)))
+
 (defmethod clock-now (clock)
   (declare (ignore clock))
   (multiple-value-bind (sec nsec) (%get-current-time)
-    (let ((sec (%adjust-sec-for-leap-seconds sec)))
-      (unix-to-timestamp sec :nsec nsec))))
+    (unix-to-timestamp sec :nsec nsec)))
 
 (defmethod clock-today (clock)
   (declare (ignore clock))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -55,6 +55,7 @@
            #:define-timezone
            #:*default-timezone*
            #:*clock*
+           #:leap-second-adjusted
            #:clock-now
            #:clock-today
            #:find-timezone-by-location-name


### PR DESCRIPTION
The new clock is off by default, and may be activated by setting
local-time:*clock* to local-time:leap-second-adjusted.