### PR TITLE
Improve timestamp printing

### DIFF
--- a/src/local-time.lisp
+++ b/src/local-time.lisp
@@ -1800,7 +1800,7 @@ You can see examples in +ISO-8601-FORMAT+, +ASCTIME-FORMAT+, and +RFC-1123-FORMA
                  (nsec-of object))))
     (t
      (when *print-escape*
-       (princ "@" stream))
+       (write-char #\@ stream))
      (format-rfc3339-timestring stream object))))
 
 (defmethod print-object ((object timezone) stream)


### PR DESCRIPTION
Use `write-char` to print the `@` before timestamp because using `princ`
uses all the printing machinery, and, most importantly, it uses sharing
detection.  So if two or more timestamps are in the same structure the
sharpsign-sharpsign syntax is used to print them.
