### PR TITLE
Fix loop initialization warnings on LispWorks.

### DIFF
--- a/src/local-time.lisp
+++ b/src/local-time.lisp
@@ -621,9 +621,9 @@ In other words:
 
   (defun %expand-adjust-timestamp-changes (timestamp changes visitor)
     (loop
-      :for change in changes
       :with params = ()
       :with functions = ()
+      :for change in changes
       :do
          (progn
            (assert (or


### PR DESCRIPTION
Fixes the following warning:

Local Variable Initialization clause (the binding of LOCAL-TIME::PARAMS) follows iteration forms but will be evaluated before them.