### PR TITLE
Alter timestamp/= to match behavior of cl:/=

### DIFF
--- a/src/local-time.lisp
+++ b/src/local-time.lisp
@@ -1176,8 +1176,14 @@ The value of this variable should have the methods `local-time::clock-now', and
 (%defcomparator timestamp=
   (eql (%timestamp-compare time-a time-b) '=))
 
-(%defcomparator timestamp/=
-  (not (eql (%timestamp-compare time-a time-b) '=)))
+(defun timestamp/= (&rest timestamps)
+  "Returns T if no pair of timestamps is equal. Otherwise return NIL."
+  (declare (dynamic-extent timestamps))
+  (loop for ts-head on timestamps do
+       (loop for ts in (rest ts-head) do
+            (when (timestamp= (car ts-head) ts)
+              (return-from timestamp/= nil))))
+  t)
 
 (defun contest (test list)
   "Applies TEST to pairs of elements in list, keeping the element which last tested T.  Returns the winning element."

--- a/test/comparison.lisp
+++ b/test/comparison.lisp
@@ -122,5 +122,7 @@
            :correct-error)))
 
 (deftest test/simple/comparison/timestamp/= ()
-  (is (timestamp/= (make-timestamp) (make-timestamp :nsec 1)))
+  (is (timestamp/= (make-timestamp :nsec 1) (make-timestamp :nsec 2)))
+  (is (timestamp/= (make-timestamp :nsec 1) (make-timestamp :nsec 2) (make-timestamp :nsec 3)))
+  (is (not (timestamp/= (make-timestamp :nsec 1) (make-timestamp :nsec 2) (make-timestamp :nsec 1))))
   (is (not (timestamp/= (make-timestamp) (make-timestamp)))))


### PR DESCRIPTION
The behavior of /= is different in that it cannot be done pair-wise, so
it needs its own implementation.

This fixes issue #72.