### PR TITLE
Add format-rfc1123-timestring documentation

### DIFF
--- a/doc/local-time.texinfo
+++ b/doc/local-time.texinfo
@@ -688,6 +688,13 @@ LOCAL-TIME> (format-timestring nil (now))
 Formats the time like format-timestring, but in RFC 3339 format. The options control valid options in the RFC.
 @end defun
 
+
+@itindex format-rfc1123-timestring
+@defun format-rfc1123-timestring (destination timestamp &key (timezone *default-timezone*))
+
+Formats the time like format-timestring, but in RFC 1123 format.
+@end defun
+
 @c ===================================================================
 @node Clocks
 @section Clocks


### PR DESCRIPTION
in `doc/local-time`.

The current documentation describes the `format-timestring` and `format-rfc3339-timestring` functions without `format-rfc1123-timestring`, and I found the latter function to be useful to know yesterday.

Thank you for maintaining this excellent library. :1st_place_medal: 