### PR TITLE
export the invalid-timestring condition

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -41,6 +41,7 @@
            #:timestamp-week
            #:timestamp-year
            #:parse-timestring
+           #:invalid-timestring
            #:format-timestring
            #:format-rfc1123-timestring
            #:to-rfc1123-timestring

--- a/test/parsing.lisp
+++ b/test/parsing.lisp
@@ -77,3 +77,5 @@
                      (with-input-from-string (ins (princ-to-string (timestamp-to-universal now)))
                        (local-time::%read-universal-time ins #\@ nil))))))
 
+(deftest test/parsing/error ()
+  (signals invalid-timestring (parse-timestring "2019-w2-20")))


### PR DESCRIPTION
Since parse-timestring is documented to signal invalid-timestring, it would seem that invalid-timestring should be exported from the local-time package. I've also added a trivial test, and the tests seem to run without any failures.
