### PR TITLE
Replace CL-FAD dependency with UIOP.

### DIFF
--- a/local-time.asd
+++ b/local-time.asd
@@ -3,7 +3,7 @@
   :license "BSD"
   :author "Daniel Lowe <dlowe@dlowe.net>"
   :description "A library for manipulating dates and times, based on a paper by Erik Naggum"
-  :depends-on (:cl-fad)
+  :depends-on (:uiop)
   :in-order-to ((test-op (test-op "local-time/test")))
   :components ((:module "src"
                         :serial t


### PR DESCRIPTION
UIOP is the defacto CL portability layer. It is also already in use by
ASDF, so this reduces dependency overhead.