### PR TITLE
stefil is marked as deprecated, should use hu.dwim.stefil

### DIFF
--- a/local-time.asd
+++ b/local-time.asd
@@ -14,9 +14,9 @@
   :version "1.0.6"
   :author "Daniel Lowe <dlowe@dlowe.net>"
   :description "Testing code for the local-time library"
-  :depends-on (:stefil
+  :depends-on (:hu.dwim.stefil
                :local-time)
-  :perform (test-op (o s) (uiop:symbol-call '#:stefil
+  :perform (test-op (o s) (uiop:symbol-call '#:hu.dwim.stefil
                                             '#:funcall-test-with-feedback-message
                                             (uiop:find-symbol* '#:test '#:local-time.test)))
   :components ((:module "test"

--- a/test/package.lisp
+++ b/test/package.lisp
@@ -3,7 +3,7 @@
 (defpackage :local-time.test
   (:use :alexandria
         :common-lisp
-        :stefil
+        :hu.dwim.stefil
         :local-time))
 
 (in-package :local-time.test)


### PR DESCRIPTION
If you look at:
https://github.com/luismbo/stefil

You'll see it's suggested to move to hu.dwim.stefil.

Thankfully this is basically trivial!
I tested locally so it should work...