### PR TITLE
Add eval-when around *abbreviated-subzone-name->timezone-list*

### DIFF
--- a/src/local-time.lisp
+++ b/src/local-time.lisp
@@ -402,10 +402,10 @@
       (t ()
         (setf *default-timezone* +utc-zone+)))))
 
-(defparameter *location-name->timezone* (make-hash-table :test 'equal)
-  "A hashtable with entries like \"Europe/Budapest\" -> timezone-instance")
-
 (eval-when (:compile-toplevel :load-toplevel :execute)
+  (defparameter *location-name->timezone* (make-hash-table :test 'equal)
+    "A hashtable with entries like \"Europe/Budapest\" -> timezone-instance")
+
   (defparameter *abbreviated-subzone-name->timezone-list* (make-hash-table :test 'equal)
     "A hashtable of \"CEST\" -> list of timezones with \"CEST\" subzone"))
 

--- a/src/local-time.lisp
+++ b/src/local-time.lisp
@@ -405,8 +405,9 @@
 (defparameter *location-name->timezone* (make-hash-table :test 'equal)
   "A hashtable with entries like \"Europe/Budapest\" -> timezone-instance")
 
-(defparameter *abbreviated-subzone-name->timezone-list* (make-hash-table :test 'equal)
-  "A hashtable of \"CEST\" -> list of timezones with \"CEST\" subzone")
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defparameter *abbreviated-subzone-name->timezone-list* (make-hash-table :test 'equal)
+    "A hashtable of \"CEST\" -> list of timezones with \"CEST\" subzone"))
 
 (defun find-timezone-by-location-name (name)
   (when (zerop (hash-table-count *location-name->timezone*))


### PR DESCRIPTION
In a recent pr *abbreviated-subzone-name->timezone-list* was added
to a macro that is used in inside an eval-when call.
We also need to add *abbreviated-subzone-name->timezone-list*
definition into eval.