### PR TITLE
Fix Error regarding Windows 10 temp file creation issue #100.

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -10,6 +10,7 @@ and worthwhile project!
     * Levente Meszaros <levente.meszaros@gmail.com>
     * Arjan Wekking <arjan@streamtech.nl>
     * Nikolai Matiushev <egao1980@gmail.com>
+    * Thomas Rake<zzzap1957@gmail.com>
 
 ------------------------------------------------------------------------
 Apologies to anyone I didn't mention (please let me know).

--- a/test/simple.lisp
+++ b/test/simple.lisp
@@ -15,7 +15,7 @@
     (is (= (day-of timestamp) 3))))
 
 (deftest test/simple/read-binary-integer ()
-  (let ((tmp-file-path #p"/tmp/local-time-test"))
+  (let ((tmp-file-path (merge-pathnames (uiop:temporary-directory) "local-time-test")))
     (with-open-file (ouf tmp-file-path
                          :direction :output
                          :element-type 'unsigned-byte


### PR DESCRIPTION
Proposed fix for issue #100 

I do not have a C:\TMP directory and adding one does fix this error. but I recall that UIOP has temporary directory access function. This pull request uses that method, which I believe is a cross platform fix.