### PR TITLE
Change PROG1 to PROGN in define-timezone

### DIFF
--- a/src/local-time.lisp
+++ b/src/local-time.lisp
@@ -449,7 +449,7 @@ found."
   (let ((zone-sym (if (symbolp zone-name)
                       zone-name
                       (intern zone-name))))
-    `(prog1
+    `(progn
          (defparameter ,zone-sym
            (make-timezone :path ,zone-file
                           :name ,(if (symbolp zone-name)

--- a/src/local-time.lisp
+++ b/src/local-time.lisp
@@ -464,7 +464,8 @@ found."
                      do
                         (push timezone
                               (gethash (subzone-abbrev subzone)
-                                       *abbreviated-subzone-name->timezone-list*)))))))))
+                                       *abbreviated-subzone-name->timezone-list*))))))
+       ,zone-sym)))
 
 (eval-when (:load-toplevel :execute)
   (let ((default-timezone-file #p"/etc/localtime"))


### PR DESCRIPTION
Getting build failures complaining about 
the existing of ANCHORAGE as a variable
in the tests with prog1. This happens in
bazel.