### PR TITLE
Fix type declaration of Windows FileTime's members in Allegro CL

### DIFF
--- a/src/local-time.lisp
+++ b/src/local-time.lisp
@@ -1065,8 +1065,8 @@ elements."
   ;; Allegro common lisp requires some toplevel hoops through which to
   ;; jump in order to call unix's gettimeofday properly.
   (ff:def-foreign-type filetime
-      (:struct (|dwLowDateTime| :int)
-               (|dwHighDateTime| :int)))
+      (:struct (|dwLowDateTime| :unsigned-long)
+               (|dwHighDateTime| :unsigned-long)))
 
   (ff:def-foreign-call
       (allegro-ffi-get-system-time-as-file-time "GetSystemTimeAsFileTime")


### PR DESCRIPTION
As per the documentation, the members of FileTime are DWORDs (32-bit unsigned integers declared as `unsigned long` in C).

Relevant documentation:
- https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime
- https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/262627d8-3418-4627-9218-4ffe110850b2

`local-time:now` returns erroneous values only sometimes (when the OS returns a number "big enough" for a wrong marshalling to occur) and I'm not really sure how to produce a test that validates/tests/protects this case, hence the lack of a test case.