### PR TITLE
Use all relevant pathname components in the default timezone repository path

### DIFF
--- a/src/local-time.lisp
+++ b/src/local-time.lisp
@@ -103,7 +103,7 @@
              (ignore-errors
                (truename
                 (merge-pathnames "zoneinfo/"
-                                 (make-pathname :directory (pathname-directory project-home-directory))))))))
+                                 (make-pathname :name nil :type nil :defaults project-home-directory)))))))
     (or (when (find-package "ASDF")
           (let ((path (eval (read-from-string
                              "(let ((system (asdf:find-system :local-time nil)))


### PR DESCRIPTION
Fixes #130. 

Now, the project home directory is used as the pathname defaults, and explicitly clearing out the name and type. All other pathname components (host, device, directory, version) will be copied into the new pathname.

Test:
```lisp
;; Assume the local-time system is in c:\quicklisp\ somewhere
> (setf *default-pathname-defaults* (make-pathname :device "z"))
#P"z:"
> (asdf:load-system "local-time")
...
> local-time::*default-timezone-repository-path*
#P"C:/quicklisp/local-projects/local-time/zoneinfo/"
> (local-time:reread-timezone-repository)
NIL
```

I did not add an explicit test for this case: it's platform- and setup- specific, and a lot of other tests already fail if `*default-timezone-repository-path*` isn't found.